### PR TITLE
Add tooltips for group slots

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -67,10 +67,14 @@ function craftguide:get_formspec(player_name, pagenum, recipe_num)
 			local X = (i-1) % width + 4.5
 			local Y = math.floor((i-1) / width + (6 - math.min(2, rows)))
 			local label = ""
-			if v:sub(1,6) == "group:" then label = "\nG" end
+			local tooltip = ""
+			if v:sub(1,6) == "group:" then
+				label = "\nG"
+				tooltip = "tooltip["..self:get_recipe(v)..";"..string.format("Any item item belonging to the %s group", v:sub(7, -1)).."]"
+			end
 
 			formspec = formspec.."item_image_button["..X..","..Y..";1,1;"..
-					     self:get_recipe(v)..";"..self:get_recipe(v)..";"..label.."]"
+					     self:get_recipe(v)..";"..self:get_recipe(v)..";"..label.."]"..tooltip
 		end
 
 		local output = recipes[recipe_num].output

--- a/init.lua
+++ b/init.lua
@@ -1,10 +1,29 @@
 local craftguide, datas, npp = {}, {}, 8*3
 
+local group_stereotypes = {
+	["wool"] = "wool:white",
+	["dye"] = "dye:white",
+	["stick"] = "default:stick",
+	["wood"] = "default:wood",
+	["stone"] = "default:cobble",
+	["book"] = "default:book",
+	["sand"] = "default:sand",
+	["tree"] = "default:tree",
+	["leaves"] = "default:leaves",
+	["water_bucket"] = "bucket:bucket_water",
+	["vessel"] = "vessels:glass_bottle",
+	["coal"] = "default:coal_lump",
+	["flower"] = "flowers:dandelion_yellow",
+	["sapling"] = "default:sapling",
+	["mesecon_conductor_craftable"] = "mesecons:wire_00000000_off",
+}
+
 function craftguide:get_recipe(item)
 	if item:sub(1,6) == "group:" then
-		if item:sub(-4) == "wool" or item:sub(-3) == "dye" then
-			item = item:sub(7)..":white"
-		elseif minetest.registered_items["default:"..item:sub(7)] then
+		local rest = item:sub(7,-1)
+		if group_stereotypes[rest] ~= nil then
+			item = group_stereotypes[rest]
+		elseif minetest.registered_items["default:"..item:sub(7,-1)] then
 			item = item:gsub("group:", "default:")
 		else for node, def in pairs(minetest.registered_items) do
 			 if def.groups[item:match("[^,:]+$")] then item = node end

--- a/init.lua
+++ b/init.lua
@@ -33,6 +33,26 @@ function craftguide:get_recipe(item)
 	return item
 end
 
+function craftguide.extract_groupnames(groupname)
+	if string.sub(groupname, 1, 6) == "group:" then
+		local group_names = string.split(string.sub(groupname, 7, -1), ",")
+		if #group_names == 1 then
+			return group_names[1], 1
+		end
+		local s = ""
+		for g=1,#group_names do
+			if g > 1 then
+				-- List connector
+				s = s .. " and "
+			end
+			s = s .. group_names[g]
+		end
+		return s, #group_names
+	else
+		return nil, 0
+	end
+end
+
 function craftguide:get_formspec(player_name, pagenum, recipe_num)
 	local data = datas[player_name]
 	local formspec = [[ size[8,6.6;]
@@ -87,9 +107,16 @@ function craftguide:get_formspec(player_name, pagenum, recipe_num)
 			local Y = math.floor((i-1) / width + (6 - math.min(2, rows)))
 			local label = ""
 			local tooltip = ""
-			if v:sub(1,6) == "group:" then
+			local groupstring_inner, groupcount = craftguide.extract_groupnames(v)
+			if groupcount > 0 then
 				label = "\nG"
-				tooltip = "tooltip["..self:get_recipe(v)..";"..string.format("Any item item belonging to the %s group", v:sub(7, -1)).."]"
+				local groupstring
+				if groupcount > 1 then
+					groupstring = string.format("Any item belonging to the following groups: %s", groupstring_inner)
+				else
+					groupstring = string.format("Any item belonging to the %s group", groupstring_inner)
+				end
+				tooltip = "tooltip["..self:get_recipe(v)..";"..minetest.formspec_escape(groupstring).."]"
 			end
 
 			formspec = formspec.."item_image_button["..X..","..Y..";1,1;"..


### PR DESCRIPTION
This PR changes the tooltips for the slots with group items (`group:whatever`).
E.g. if you have a `group:wood` in a recipe, like for the chest, the tooltips for those slots is now changed to “Any item belonging to the wood group”.
AND-combined groups (e.g. `group:dye,excolor_violet`) are supported, too.

And lastly, the item images are adjusted for some of the groups (different “stereotypical” item images which I think are more appropriate for the group).