### PR TITLE
Cycle through alternative receipes when re-clicking on same item

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -167,7 +167,7 @@ function craftguide:get_formspec(player_name, is_fuel)
 			tooltip[clear;Reset]
 			tooltip[size_inc;Increase window size]
 			tooltip[size_dec;Decrease window size]
-			field_close_on_enter[filter, false] ]]..
+			field_close_on_enter[filter;false] ]]..
 			"button["..(data.iX/2)..",-0.02;0.7,1;size_inc;+]"..
 			"button["..((data.iX/2) + 0.5)..
 				",-0.02;0.7,1;size_dec;-]"..
@@ -465,4 +465,3 @@ mt.register_craft({
 })
 
 mt.register_alias("xdecor:crafting_guide", "craftguide:book")
-

--- a/init.lua
+++ b/init.lua
@@ -365,20 +365,34 @@ mt.register_on_player_receive_fields(function(player, formname, fields)
 			local is_fuel = get_fueltime(item) > 0
 			if not recipes and not is_fuel then return end
 
-			if progressive_mode then
-				local inv = player:get_inventory()
-				local _, has_item =
-					craftguide:recipe_in_inv(inv, item)
+			local is_fuel = get_fueltime(item) > 0
+			local recipes = get_recipes(item)
+			if not recipes and not is_fuel then return end
 
-				if not has_item then return end
-				recipes = craftguide:recipe_in_inv(
-							inv, item, recipes)
+			if item == data.item then
+				-- Cycle through alternatives when clicking same item again
+				if data.recipes_item and #data.recipes_item >= 2 then
+					local recipe = data.recipes_item[data.recipe_num + 1]
+					data.recipe_num = recipe and data.recipe_num + 1 or 1
+					craftguide:get_formspec(player_name)
+				end
+			else
+
+				if progressive_mode then
+					local inv = player:get_inventory()
+					local _, has_item =
+						craftguide:recipe_in_inv(inv, item)
+
+					if not has_item then return end
+					recipes = craftguide:recipe_in_inv(
+								inv, item, recipes)
+				end
+
+				data.item = item
+				data.recipe_num = 1
+				data.recipes_item = recipes
+				craftguide:get_formspec(player_name, is_fuel)
 			end
-
-			data.item = item
-			data.recipe_num = 1
-			data.recipes_item = recipes
-			craftguide:get_formspec(player_name, is_fuel)
 		end
 	     end
 	end

--- a/init.lua
+++ b/init.lua
@@ -361,10 +361,6 @@ mt.register_on_player_receive_fields(function(player, formname, fields)
 				item = item:sub(1,-5)
 			end
 
-			local recipes = get_recipes(item)
-			local is_fuel = get_fueltime(item) > 0
-			if not recipes and not is_fuel then return end
-
 			local is_fuel = get_fueltime(item) > 0
 			local recipes = get_recipes(item)
 			if not recipes and not is_fuel then return end


### PR DESCRIPTION
This PR adds a simple usability improvement:
When you click on the button which is already the currently displayed output, the craft guide now shows the next alternative recipe (if available). This can be very useful to quickly cycle through all alternatives simply by clicking the same item button again and again. This also reduces the way the mouse has to go.

Before this PR, pressing the button of the current recipe output either did nothing or reset the recipe alternative to 1, which was not really useful.