### PR TITLE
Add sfinv_buttons support

### DIFF
--- a/depends.txt
+++ b/depends.txt
@@ -1,0 +1,1 @@
+sfinv_buttons?

--- a/init.lua
+++ b/init.lua
@@ -474,4 +474,15 @@ mt.register_craft({
 	burntime = 10
 })
 
+if mt.get_modpath("sfinv_buttons") then
+	sfinv_buttons.register_button("craftguide", {
+		title = "Crafting guide",
+		tooltip = "Shows a list of available crafting recipes, cooking recipes and fuels",
+		action = function(player)
+			craftguide:on_use(nil, player)
+		end,
+		image = "craftguide_book.png",
+	})
+end
+
 mt.register_alias("xdecor:crafting_guide", "craftguide:book")


### PR DESCRIPTION
This PR (optionally) adds a button in the Simple Fast Inventory by rubenwardy (core feature in Minetest Game) by using the mod `sfinv_buttons`. This allows the player to always access the crafting guide, regardless of items.

Read more about the mod here:
https://forum.minetest.net/viewtopic.php?f=9&t=16079